### PR TITLE
Bump commons-io from 2.6 to 2.7 in /spring-jdbc

### DIFF
--- a/spring-jdbc/pom.xml
+++ b/spring-jdbc/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumps commons-io from 2.6 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>